### PR TITLE
Send back a formatted expiry date to WHMCS instead of Carbon

### DIFF
--- a/modules/registrars/netistrar/netistrar.php
+++ b/modules/registrars/netistrar/netistrar.php
@@ -1235,7 +1235,7 @@ function netistrar_Sync($params) {
     if ($domainInfo instanceof Domain) {
         $status = $domainInfo->getRegistrationStatus();
 
-        $returnArray["expirydate"] = $domainInfo->getExpiryDate();
+        $returnArray["expirydate"] = $domainInfo->getExpiryDate()->format('Y-m-d);
 
         if ($status != "ACTIVE") {
             $returnArray["active"] = false;


### PR DESCRIPTION
Sending back Carbon triggers WHMCS into thinking the date has changed, preventing 'In Sync' from showing in the sync report.